### PR TITLE
Minor change to authentication.jsx to fix issue #52

### DIFF
--- a/src/components/authentication.jsx
+++ b/src/components/authentication.jsx
@@ -34,8 +34,8 @@ export const Authentication = (props) => {
         
         /// Logout function, used with the Authentication Context
         function logout() {
-            setAuthUser(null);
             window.localStorage.removeItem("auth");
+            window.location.reload();
         }
         
 


### PR DESCRIPTION
### Dependencies:
- None

Pull request/commit to solve issue #52. When logging out, you are not returned to the login page on the crew page. Only a blank page is shown. This is caused by setAuthState(null) which triggers the React router to send you to /login, but doesn't refresh and show the login page. This PR hopefully solves this.